### PR TITLE
Add support for extra environment variables

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -45,9 +45,12 @@ spec:
           volumeMounts:
             - name: vol-yet-another-cloudwatch-exporter
               mountPath: /config
-        {{- if not .Values.aws.role }}
-        {{- if .Values.aws.secret.name }}
           env:
+            {{- if .Values.extraEnv }}
+              {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
+            {{- if not .Values.aws.role }}
+            {{- if .Values.aws.secret.name }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -58,15 +61,14 @@ spec:
                 secretKeyRef:
                   key: secret_key
                   name: {{ .Values.aws.secret.name }}
-          {{- if .Values.aws.secret.includesSessionToken }}
+            {{- if .Values.aws.secret.includesSessionToken }}
             - name: AWS_SESSION_TOKEN
               valueFrom:
                 secretKeyRef:
                   key: security_token
                   name: {{ .Values.aws.secret.name }}
-          {{- end }}
-          {{- else if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
-          env:
+            {{- end }}
+            {{- else if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -77,8 +79,8 @@ spec:
                 secretKeyRef:
                   key: aws_secret_access_key
                   name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
-          {{- end }}
-          {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: {{ .Values.portName }}
               containerPort: 5000

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -82,6 +82,11 @@ tolerations: []
 
 affinity: {}
 
+
+extraEnv: []
+  # Define extra environmental variables list as follows
+  # - name : key1,
+  #   value: value1
 extraArgs: []
 #   decoupled-scraping: false
 #   scraping-interval: 300

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -85,7 +85,7 @@ affinity: {}
 
 extraEnv: []
   # Define extra environmental variables list as follows
-  # - name : key1,
+  # - name : key1
   #   value: value1
 extraArgs: []
 #   decoupled-scraping: false


### PR DESCRIPTION
Glad to see that you have moved the helm-charts into a separate repository. Way to go!

There are certain situations we need to deploy this helm chart where it requires extra env variables. 

i.e cooperate environments normally operates behind proxy servers, hence to gain access to AWS tagging apis and other apis it requires to set proxy variables as follows as env variables inside the deployment.
`http_proxy` and `https_proxy` etc. 

I have tested this PR on AWS EKS cluster and it works fine with extra environment variables. 