### PR TITLE
feat: allow adding annotations to the Service

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/templates/service.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
   labels:
     {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -43,6 +43,8 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  # -- Annotations to add to the service
+  annotations: {}
 
 testConnection: true
 


### PR DESCRIPTION
Example use case: add the "prometheus.io/scrape: true" annotation on the service (not the pods themselves).
Directly scrapping the service allows not to have new series whenever the exporter pod is recreated with a new name, as series scrapped from pods typically include the pod name in their labels.