### PR TITLE
Add extraVolumes and extraVolumeMounts

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/README.md
+++ b/charts/yet-another-cloudwatch-exporter/README.md
@@ -30,6 +30,8 @@ helm install nerdswords/yet-another-cloudwatch-exporter
 | config | string | `"apiVersion: v1alpha1\nsts-region: eu-west-1\ndiscovery:\n  exportedTagsOnMetrics:\n    ec2:\n      - Name\n    ebs:\n      - VolumeId\n  jobs:\n  - type: es\n    regions:\n      - eu-west-1\n    searchTags:\n      - key: type\n        value: ^(easteregg|k8s)$\n    metrics:\n      - name: FreeStorageSpace\n        statistics:\n        - Sum\n        period: 60\n        length: 600\n      - name: ClusterStatus.green\n        statistics:\n        - Minimum\n        period: 60\n        length: 600\n      - name: ClusterStatus.yellow\n        statistics:\n        - Maximum\n        period: 60\n        length: 600\n      - name: ClusterStatus.red\n        statistics:\n        - Maximum\n        period: 60\n        length: 600"` |  |
 | extraArgs | object | `{}` |  |
 | extraEnv | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/nerdswords/yet-another-cloudwatch-exporter"` |  |

--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           volumeMounts:
             - name: vol-yet-another-cloudwatch-exporter
               mountPath: /config
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12}}
+            {{- end }}
           env:
             {{- if .Values.extraEnv }}
               {{- toYaml .Values.extraEnv | nindent 12 }}
@@ -111,7 +114,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      - configMap:
-          defaultMode: 420
-          name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
-        name: vol-yet-another-cloudwatch-exporter
+        - configMap:
+            defaultMode: 420
+            name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+          name: vol-yet-another-cloudwatch-exporter
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8}}
+      {{- end }}

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -93,6 +93,20 @@ extraEnv: []
 extraArgs: {}
   # scraping-interval: 300
 
+extraVolumeMounts: []
+  # Additional volumeMounts to the container.
+  # - name: secrets-store01-inline
+  #   mountPath: /mnt/secrets-store
+
+extraVolumes: []
+# Additional volumes to the pod.
+# - csi:
+#     driver: secrets-store.csi.k8s.io
+#     readOnly: true
+#     volumeAttributes:
+#       secretProviderClass: "secret-csi-provider"
+#   name : secrets-store01-inline
+
 aws:
   role:
 


### PR DESCRIPTION
This pull request enhances the Helm chart to allow the provisioning of additional volumes and mounts for the deployment.

One specific use case is the integration of the Secrets Store CSI Driver. Instead of storing AWS access credentials in the repository, it's possible to securely store them in an external Secrets Manager. The secret will automatically sync when a pod requests the mount, thus the need to provide extra volumes and mounts to the deployment.