### PR TITLE
feat: allow adding labels to the serviceaccount

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/README.md
+++ b/charts/yet-another-cloudwatch-exporter/README.md
@@ -58,6 +58,7 @@ helm install nerdswords/yet-another-cloudwatch-exporter
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.labels | object | `{}` | Labels to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.enabled | bool | `false` |  |
 | testConnection | bool | `true` |  |

--- a/charts/yet-another-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "yet-another-cloudwatch-exporter.serviceAccountName" . }}
   labels:
     {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -17,6 +17,8 @@ fullnameOverride: ""
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
+  # -- Labels to add to the service account
+  labels: {}
   # -- Annotations to add to the service account
   annotations: {}
   # -- The name of the service account to use.


### PR DESCRIPTION
This pull request introduces a new feature to the Helm chart that allows users to customize the labels of the ServiceAccount resources. With this enhancement, you can now easily apply specific labels to ServiceAccounts to better organize and manage your Kubernetes resources.

To customize the labels, you can use the following parameters in the values.yaml file:

`serviceAccount.labels`: This parameter accepts a map of key-value pairs representing the labels you want to apply to the ServiceAccount.

By leveraging this parameter, you can tailor the ServiceAccount labels to match your specific requirements and best practices within your Kubernetes environment.