### PR TITLE
Add support for extraEnvFrom variables

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/README.md
+++ b/charts/yet-another-cloudwatch-exporter/README.md
@@ -30,6 +30,7 @@ helm install nerdswords/yet-another-cloudwatch-exporter
 | config | string | `"apiVersion: v1alpha1\nsts-region: eu-west-1\ndiscovery:\n  exportedTagsOnMetrics:\n    ec2:\n      - Name\n    ebs:\n      - VolumeId\n  jobs:\n  - type: es\n    regions:\n      - eu-west-1\n    searchTags:\n      - key: type\n        value: ^(easteregg|k8s)$\n    metrics:\n      - name: FreeStorageSpace\n        statistics:\n        - Sum\n        period: 60\n        length: 600\n      - name: ClusterStatus.green\n        statistics:\n        - Minimum\n        period: 60\n        length: 600\n      - name: ClusterStatus.yellow\n        statistics:\n        - Maximum\n        period: 60\n        length: 600\n      - name: ClusterStatus.red\n        statistics:\n        - Maximum\n        period: 60\n        length: 600"` |  |
 | extraArgs | object | `{}` |  |
 | extraEnv | list | `[]` |  |
+| extraEnvFrom | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
                   name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
             {{- end }}
             {{- end }}
+            {{- if .Values.extraEnvFrom }}
+          envFrom:
+              {{- toYaml .Values.extraEnvFrom | nindent 12 }}
+            {{- end }}
           ports:
             - name: {{ .Values.portName }}
               containerPort: 5000

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -91,6 +91,11 @@ extraEnv: []
   # Define extra environmental variables list as follows
   # - name : key1
   #   value: value1
+ 
+extraEnvFrom: []
+  # Define extra environmental variables from secrets or configmaps
+  # - secretRef:
+  #     name: secrets
 
 extraArgs: {}
   # scraping-interval: 300


### PR DESCRIPTION
This pull request is an enhancement to the Helm chart to add support for 'extraEnvFrom' environment variables from secrets or configmaps.

This capability is useful in scenarios when secrets need to be passed as environment variables to the running container.