### PR TITLE
ci: Release helm charts as OCI artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,24 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "yace-helm-chart-{{ .Version }}"
 
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done
+
   sync-readme:
     needs: [release]
     permissions:


### PR DESCRIPTION
Helm supports helm charts as OCI artifact, too. This has the great benefit that a local configuration of a helm repo is not longer necessary.

Ref: prometheus-community/helm-charts@17736ad/.github/workflows/release.yaml#L45C1-L61C15