### PR TITLE
adding [annotations] directly to the top [metadata] section of the deployment yaml template

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.27.0
-appVersion: "v0.56.0"
+version: 0.28.0
+appVersion: "v0.57.0"
 home: https://github.com/nerdswords/helm-charts
 sources:
 - https://github.com/nerdswords/yet-another-cloudwatch-exporter

--- a/charts/yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.29.0
+version: 0.31.0
 appVersion: "v0.57.1"
 home: https://github.com/nerdswords/helm-charts
 sources:

--- a/charts/yet-another-cloudwatch-exporter/README.md
+++ b/charts/yet-another-cloudwatch-exporter/README.md
@@ -1,6 +1,6 @@
 # yet-another-cloudwatch-exporter
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.56.0](https://img.shields.io/badge/AppVersion-v0.56.0-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.57.0](https://img.shields.io/badge/AppVersion-v0.57.0-informational?style=flat-square)
 
 Yace - Yet Another CloudWatch Exporter
 

--- a/charts/yet-another-cloudwatch-exporter/README.md
+++ b/charts/yet-another-cloudwatch-exporter/README.md
@@ -1,6 +1,6 @@
 # yet-another-cloudwatch-exporter
 
-![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.57.1](https://img.shields.io/badge/AppVersion-v0.57.1-informational?style=flat-square)
+![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.57.1](https://img.shields.io/badge/AppVersion-v0.57.1-informational?style=flat-square)
 
 Yace - Yet Another CloudWatch Exporter
 

--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
-  annotations:
-    {{- with .Values.podAnnotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- with .Values.podAnnotations }}
+  annotations:    
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:


### PR DESCRIPTION
I'd like to add [annotations] directly to the top [metadata] section of the deployment yaml template in YACE helm chart. This is because I'm deploying application in a Kubernetes environment using YACE as a helm chart for cloud watch exporting, and there's a requirement for annotations in the metadata in accordance with the org's deployment policy.