### PR TITLE
fix sa manifest skip

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.33.0
+version: 0.34.0
 appVersion: "v0.58.0"
 home: https://github.com/nerdswords/helm-charts
 sources:

--- a/charts/yet-another-cloudwatch-exporter/README.md
+++ b/charts/yet-another-cloudwatch-exporter/README.md
@@ -1,6 +1,6 @@
 # yet-another-cloudwatch-exporter
 
-![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.58.0](https://img.shields.io/badge/AppVersion-v0.58.0-informational?style=flat-square)
+![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.58.0](https://img.shields.io/badge/AppVersion-v0.58.0-informational?style=flat-square)
 
 Yace - Yet Another CloudWatch Exporter
 

--- a/charts/yet-another-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -13,5 +13,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}  
 {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+


### PR DESCRIPTION
if 
```
serviceAccount:
  create: false
```
helm renders empty file which can't be applied
```
---
# Source: yet-another-cloudwatch-exporter/templates/serviceaccount.yaml
automountServiceAccountToken: true
---
```  