### PR TITLE
Remove API check for Prom resources

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.prometheusRule.enabled ) }}
+{{- if .Values.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/charts/yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Currently we check if the cluster got the `ServiceMonitor` and `PrometheusRule` available before installing the resources.

I like get the overall idea but I think it will be beneficial to only rely on the user input `.serviceMonitor.enabled`:
* Less confusing: I activated the `serviceMonitor` but somehow the resource isn't created. Why is that? (I better just fail)
* Better 3nd party integration: API check doesn't work well with `helm template` command. (I actually using `Flux` who apparently does validation using `helm template`)
* Consistent: I use a lot of helm release yet that the first time I bump into this integration problem. It's because usually other [check doesn't check for the API resource](https://github.com/gruntwork-io/helm-kubernetes-services/blob/main/charts/k8s-service/templates/serviceaccount.yaml#L1)